### PR TITLE
Fixes for OpenCart DB column name changes

### DIFF
--- a/src/OpenCartTest.php
+++ b/src/OpenCartTest.php
@@ -108,13 +108,13 @@ class OpenCartTest extends PHPUnit_Framework_TestCase {
 				$db->query("INSERT INTO `" . DB_PREFIX . "user` SET user_id = '1', user_group_id = '1', username = 'admin', salt = '" . $db->escape($salt = substr(md5(uniqid(rand(), true)), 0, 9)) . "', password = '" . $db->escape(sha1($salt . sha1($salt . sha1('admin')))) . "', status = '1', email = '" . $db->escape('admin@localhost') . "', date_added = NOW()");
 
 				$db->query("DELETE FROM `" . DB_PREFIX . "setting` WHERE `key` = 'config_email'");
-				$db->query("INSERT INTO `" . DB_PREFIX . "setting` SET `group` = 'config', `key` = 'config_email', value = '" . $db->escape('admin@localhost') . "'");
+				$db->query("INSERT INTO `" . DB_PREFIX . "setting` SET `code` = 'config', `key` = 'config_email', value = '" . $db->escape('admin@localhost') . "'");
 
 				$db->query("DELETE FROM `" . DB_PREFIX . "setting` WHERE `key` = 'config_url'");
-				$db->query("INSERT INTO `" . DB_PREFIX . "setting` SET `group` = 'config', `key` = 'config_url', value = '" . $db->escape($_SERVER['HTTP_HOST']) . "'");
+				$db->query("INSERT INTO `" . DB_PREFIX . "setting` SET `code` = 'config', `key` = 'config_url', value = '" . $db->escape($_SERVER['HTTP_HOST']) . "'");
 
 				$db->query("DELETE FROM `" . DB_PREFIX . "setting` WHERE `key` = 'config_encryption'");
-				$db->query("INSERT INTO `" . DB_PREFIX . "setting` SET `group` = 'config', `key` = 'config_encryption', value = '" . $db->escape(md5(mt_rand())) . "'");
+				$db->query("INSERT INTO `" . DB_PREFIX . "setting` SET `code` = 'config', `key` = 'config_encryption', value = '" . $db->escape(md5(mt_rand())) . "'");
 
 				$db->query("UPDATE `" . DB_PREFIX . "product` SET `viewed` = '0'");
 			}
@@ -219,7 +219,7 @@ class OpenCartTest extends PHPUnit_Framework_TestCase {
 		
 		// Language
 		$language = new Language($languages[$code]['directory']);
-		$language->load($languages[$code]['filename']);
+		$language->load($languages[$code]['directory']);
 		$this->registry->set('language', $language);
 		
 		// Document


### PR DESCRIPTION
In the table `oc_setting` the column `group` is now `code`.
The `Language` class now loads the directory instead of a filename.